### PR TITLE
Laravel 8 + plus a few other configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## 1.1.0
+- Bumped Support for Laravel 8
+- Added ability to add any further options to `SNSClient` config (i.e. to override `endpoint`)
+- *Breaking Change*: Inherited the name to the `Subject` field of an SNS Message. This either comes from `broadcastAs()` or the Class name ([see here](https://laravel.com/docs/8.x/broadcasting#broadcast-name) for more info). The last change is potentially breaking if one did not want the subject set.
+
 ## 1.0.1
 * Allow using IAM Role
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "aws"
   ],
   "require": {
-    "php": ">=7.4 <=8.3",
+    "php": ">=7.4 <8.4",
     "ext-json": "*",
     "illuminate/broadcasting": ">=6 <=11",
     "illuminate/support": ">=6 <=11",

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-  "name": "maxgaurav/laravel-sns-broadcaster",
+  "name": "alexw23/laravel-sns-broadcaster",
   "description": "Sns Messages as queues using extended laravel sqs driver.",
   "type": "library",
   "license": "MIT",
-  "homepage": "https://github.com/maxgaurav/laravel-sns-broadcaster",
+  "homepage": "https://github.com/alexw23/laravel-sns-broadcaster",
   "authors": [
     {
-      "name": "Max Gaurav",
-      "email": "max.gaurav@ithands.net"
+      "name": "Alex Whiteside",
+      "email": "alexwhiteside@ignitedlabs.com.au"
     }
   ],
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
   "require": {
     "php": ">=7.4 <8.4",
     "ext-json": "*",
-    "illuminate/broadcasting": ">=6 <=11",
-    "illuminate/support": ">=6 <=11",
-    "illuminate/contracts": ">=6 <=11",
-    "illuminate/config": ">=6 <=11",
+    "illuminate/broadcasting": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+    "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+    "illuminate/contracts": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+    "illuminate/config": "^8.0 || ^9.0 || ^10.0 || ^11.0",
     "aws/aws-sdk-php": "^3.305"
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     "aws"
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^8.2",
     "ext-json": "*",
-    "illuminate/broadcasting": "6.* || 7.* || 8.*",
-    "illuminate/support": "6.* || 7.* || 8.*",
-    "illuminate/contracts": "6.* || 7.* || 8.*",
-    "illuminate/config": "6.* || 7.* || 8.*",
-    "aws/aws-sdk-php": "^3.62"
+    "illuminate/broadcasting": ">=6 <=11",
+    "illuminate/support": ">=6 <=11",
+    "illuminate/contracts": ">=6 <=11",
+    "illuminate/config": ">=6 <=11",
+    "aws/aws-sdk-php": "^3.305"
   },
   "config": {
     "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "aws"
   ],
   "require": {
-    "php": "^8.2",
+    "php": ">=7.4 <=8.3",
     "ext-json": "*",
     "illuminate/broadcasting": ">=6 <=11",
     "illuminate/support": ">=6 <=11",

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
   "require": {
     "php": "^7.2",
     "ext-json": "*",
-    "illuminate/broadcasting": "6.* || 7.*",
-    "illuminate/support": "6.* || 7.*",
-    "illuminate/contracts": "6.* || 7.*",
-    "illuminate/config": "6.* || 7.*",
+    "illuminate/broadcasting": "6.* || 7.* || 8.*",
+    "illuminate/support": "6.* || 7.* || 8.*",
+    "illuminate/contracts": "6.* || 7.* || 8.*",
+    "illuminate/config": "6.* || 7.* || 8.*",
     "aws/aws-sdk-php": "^3.62"
   },
   "config": {

--- a/src/LaravelSnsBroadcastProvider.php
+++ b/src/LaravelSnsBroadcastProvider.php
@@ -41,6 +41,10 @@ class LaravelSnsBroadcastProvider extends ServiceProvider
             );
         }
 
+        if(!empty($config['options']) && is_array($config['options'])) {
+            $snsConfig = array_merge($snsConfig, $config['options']);
+        }
+
         return $snsConfig;
     }
 }

--- a/src/SnsBroadcaster.php
+++ b/src/SnsBroadcaster.php
@@ -44,6 +44,7 @@ class SnsBroadcaster implements Broadcaster
     {
         $this->snsClient->publish([
             'TopicArn' => $this->topicName($channels),
+            'Subject' => $event,
             'Message' => json_encode(Arr::except($payload, 'socket')),
         ]);
     }


### PR DESCRIPTION
Just wanted to open a PR, but also happy to work from my master.

3 Updates in this PR:
- Bumped Support for Laravel 8
- Added ability to add any further options to `SNSClient` config (so I can override `endpoint`)
- Inherited the name to the `Subject` field of an SNS Message. This either comes from `broadcastAs()` or the Class name ([see here](https://laravel.com/docs/8.x/broadcasting#broadcast-name) for more info). The last one could potentially be a breaking change if one did not want this set, so probably ideal to bump a major.

Note changelog already implies that you would bump to `1.1` given the above addressed potentially breaking change.